### PR TITLE
feat: change surface--hovered to slate-100

### DIFF
--- a/.changeset/quiet-hounds-boil.md
+++ b/.changeset/quiet-hounds-boil.md
@@ -1,0 +1,5 @@
+---
+'@nelson-ui/theme': patch
+---
+
+Change surface-hovered to slate-100

--- a/packages/theme/src/generated.ts
+++ b/packages/theme/src/generated.ts
@@ -45,7 +45,7 @@ export const colors = {
     success: 'color-green-600',
     surface: 'color-base-white',
     'surface--disabled': 'color-slate-100',
-    'surface--hovered': 'color-slate-050',
+    'surface--hovered': 'color-slate-100',
     'surface--pressed': 'color-slate-200',
     'surface--selected': 'color-blue-050',
     'surface-accent': 'color-blue-050',


### PR DESCRIPTION
After a conversation with @fungiblejasper we decided to update this to `slate-100` because the previous value was super hard to see on my screen when used for main nav.

We're aware the hover colour is now the same as `subdued` and `disabled` but Jasper believes we don't have cases of hovering a subdued surface so it shouldn't be a problem.

Let us know if we've missed an edge-case though if you think this might cause issues.