### PR TITLE
fix: prevent horizontal stack blowout

### DIFF
--- a/.changeset/tasty-pants-knock.md
+++ b/.changeset/tasty-pants-knock.md
@@ -1,0 +1,5 @@
+---
+'@nelson-ui/react': patch
+---
+
+Prevent horizontal stack blowout

--- a/packages/react/src/flex.tsx
+++ b/packages/react/src/flex.tsx
@@ -2,5 +2,11 @@ import React, { forwardRef } from 'react';
 import { Box, BoxProps } from './box';
 
 export const Flex = forwardRef<HTMLElement, BoxProps>((props, ref) => (
-  <Box ref={ref} display="flex" {...props} />
+  <Box
+    ref={ref}
+    display="flex"
+    // prevent flex blowout. content should never be wider than the stack.
+    minWidth={0}
+    {...props}
+  />
 ));


### PR DESCRIPTION
i've been looking into collection name truncation issues on the gamma.io website (some of which i caused in a recent PR) and it seems there are some JS workarounds in the `CollectionName` component that i think could be solved by CSS. i'm specifically referring to the `offset` prop + manual shortening of string (what was this historically for?).

if we update stack to avoid horizontal blowout, css truncate should automatically work. most of the time this is the desired behaviour but it can of course be overridden if blowout is needed.

i did a find+replace on `<Stack ` to `<Stack minWidth={0} ` and `<Flex ` to `<Flex minWidth={0} ` in the gamma.io website and tested the happy paths to check nothing will be broken by this change.